### PR TITLE
Notification modules bug fixes

### DIFF
--- a/src/app/api/(notifications)/notifications/send-notification/seller/route.ts
+++ b/src/app/api/(notifications)/notifications/send-notification/seller/route.ts
@@ -3,6 +3,7 @@ import { NextRequest, NextResponse } from "next/server";
 
 interface INotificationSendBody {
     seller_id: string;
+    order_id: string;
 };
 
 async function handler (request: NextRequest) {
@@ -17,16 +18,16 @@ async function handler (request: NextRequest) {
                 subscriber_id: parseInt(body.seller_id),
                 items: {
                     create: {
-                        title: "Pesanan baru telah diterima.",
-                        redirect_url: "/seller/dashboard/orders?state=PAID"
+                        title: `Pesanan baru dengan ID ${body.order_id} telah diterima.`,
+                        redirect_url: "/user/dashboard/seller-orders?state=PAID"
                     }
                 }
             },
             update: {
                 items: {
                     create: {
-                        title: "Pesanan baru telah diterima.",
-                        redirect_url: "/seller/dashboard/orders?state=PAID"
+                        title: `Pesanan baru dengan ID ${body.order_id} telah diterima.`,
+                        redirect_url: "/user/dashboard/seller-orders?state=PAID"
                     }
                 }
             },

--- a/src/app/api/(payments)/payment-success/route.ts
+++ b/src/app/api/(payments)/payment-success/route.ts
@@ -43,7 +43,8 @@ async function handler(request: NextRequest) {
       });
 
       const sendSellerNotification = sendSellerNotificationHandler({
-        seller_id: productOrder.order_item[0].product.seller_id.toString()
+        seller_id: productOrder.order_item[0].product.seller_id.toString(),
+        order_id: orderID,
       });
 
       await Promise.all([updateOrderStatus, sendCustomerNotification, sendSellerNotification]).then(() => redirect(ROUTES.USER.ORDERS));

--- a/src/app/api/order/update-status/route.ts
+++ b/src/app/api/order/update-status/route.ts
@@ -27,11 +27,6 @@ async function handler(request: NextRequest) {
         message: `Pesanan dengan ID ${body.order_id} sedang dikemas.`,
         redirect_url: "/user/dashboard/orders?state=PACKED",
       };
-    } else if (body.order_status === "DELIVERED") {
-      return {
-        message: `Pesanan dengan ID ${body.order_id} telah diterima oleh pelanggan.`,
-        redirect_url: "/seller/dashboard/orders?state=DELIVERED",
-      };
     }
   }
 
@@ -92,17 +87,11 @@ async function handler(request: NextRequest) {
         if (updateOrderStatus) {
           const _notificationDetail = notificationDetail();
           if (_notificationDetail) {
-            const customerNotification = sendNotificationHandler({
+            await sendNotificationHandler({
               notification_redirect_url: _notificationDetail.redirect_url,
               notification_title: _notificationDetail.message,
               subscriber_target: updateOrderStatus.user_id.toString(),
             });
-
-            const sellerNotification = sendSellerNotificationHandler({
-              seller_id: updateOrderStatus.order_item[0].product.seller_id.toString(),
-            });
-
-            await Promise.all([customerNotification, sellerNotification]);
           }
           revalidateTag("seller-orders");
           return NextResponse.json({

--- a/src/lib/actions/notification.ts
+++ b/src/lib/actions/notification.ts
@@ -131,6 +131,7 @@ export async function sendNotificationHandler(
 export async function sendSellerNotificationHandler(
     body: {
         seller_id: string;
+        order_id: string;
     }
 ) {
     const res = await fetch(process.env.NEXT_PUBLIC_API_NOTIFICATION_SEND_SELLER!, {
@@ -140,6 +141,7 @@ export async function sendSellerNotificationHandler(
         },
         body: JSON.stringify({
             seller_id: body.seller_id,
+            order_id: body.order_id
         })
     })
 


### PR DESCRIPTION
This PR includes:
- The notification will only sent to the seller if only the order has been paid successfully by the customer
- The notification `redirect_url` for the seller notification was fixed
- Adding `order_id` to the seller notification message payload.