### PR TITLE
Add order sorting functionality to customer and seller order lists

### DIFF
--- a/src/app/api/(user)/get-user-orders/[id]/route.ts
+++ b/src/app/api/(user)/get-user-orders/[id]/route.ts
@@ -42,6 +42,9 @@ async function handler(
         },
       },
     },
+    orderBy: {
+      order_date: "desc"
+    }
   });
 
   if (userOrders) {

--- a/src/app/api/order/list-seller-orders/route.ts
+++ b/src/app/api/order/list-seller-orders/route.ts
@@ -56,6 +56,9 @@ async function handler(request: NextRequest) {
             },
           },
         },
+        orderBy: {
+          order_date: "desc",
+        },
       });
 
       if (sellerOrders) {

--- a/src/components/ui/customer-order-list.tsx
+++ b/src/components/ui/customer-order-list.tsx
@@ -1,10 +1,13 @@
 "use client";
 
 import { ORDER_STATUS, TCustomerOrder } from "@/lib/globals";
-import OrderCard from "./order-card";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "./tabs";
 import { useSearchParams } from "next/navigation";
 import { sortOrders } from "@/lib/helper";
+import dynamic from "next/dynamic";
+import Loading from "@/app/loading";
+
+const OrderCard = dynamic(() => import("./order-card"), {ssr: false, loading: () => <Loading />})
 
 interface ICustomerOrdersListProps {
   orders: TCustomerOrder[];

--- a/src/components/ui/customer-order-list.tsx
+++ b/src/components/ui/customer-order-list.tsx
@@ -4,6 +4,7 @@ import { ORDER_STATUS, TCustomerOrder } from "@/lib/globals";
 import OrderCard from "./order-card";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "./tabs";
 import { useSearchParams } from "next/navigation";
+import { sortOrders } from "@/lib/helper";
 
 interface ICustomerOrdersListProps {
   orders: TCustomerOrder[];
@@ -18,7 +19,7 @@ export default function CustomerOrderList({
   const orderState = searchParams.get("state") ?? "ALL";
   
   const ordersData = {
-    ALL: orders,
+    ALL: sortOrders(orders),
     PENDING: orders.filter((order) => order.order_status === "PENDING"),
     PAID: orders.filter((order) => order.order_status === "PAID"),
     PACKED: orders.filter((order) => order.order_status === "PACKED"),
@@ -55,7 +56,7 @@ export default function CustomerOrderList({
       </TabsList>
 
       <TabsContent value="ALL">
-        <OrderCard ordersData={ordersData.ALL} />
+        <OrderCard ordersData={ordersData.ALL as TCustomerOrder[]} />
       </TabsContent>
       <TabsContent value="PENDING">
         <OrderCard ordersData={ordersData.PENDING} />

--- a/src/lib/helper.ts
+++ b/src/lib/helper.ts
@@ -3,6 +3,8 @@ import {
   TProduct,
   ORDER_STATUS,
   TProductVariantItem,
+  TOrder,
+  TCustomerOrder,
 } from "./globals";
 import supabase from "./supabase";
 
@@ -427,3 +429,17 @@ export const showProductSoldCount = (sold_count: number) => {
     return "99+"
   }
 }
+
+export const sortOrders = (orders: TOrder[] | TCustomerOrder[]) => {
+  const firstOrdersStatus: ORDER_STATUS = "PENDING";
+  
+  const sortedOrders = orders.sort((a, b) => {
+    if (a.order_status === firstOrdersStatus) {
+      return -1;
+    } else {
+      return 0;
+    }
+  });
+
+  return sortedOrders;
+};

--- a/src/lib/helper.ts
+++ b/src/lib/helper.ts
@@ -3,8 +3,8 @@ import {
   TProduct,
   ORDER_STATUS,
   TProductVariantItem,
-  TOrder,
   TCustomerOrder,
+  TSellerOrder,
 } from "./globals";
 import supabase from "./supabase";
 
@@ -430,7 +430,7 @@ export const showProductSoldCount = (sold_count: number) => {
   }
 }
 
-export const sortOrders = (orders: TOrder[] | TCustomerOrder[]) => {
+export const sortOrders = (orders: TSellerOrder[] | TCustomerOrder[]) => {
   const firstOrdersStatus: ORDER_STATUS = "PENDING";
   
   const sortedOrders = orders.sort((a, b) => {

--- a/src/lib/hooks/context/useOrderManagement.tsx
+++ b/src/lib/hooks/context/useOrderManagement.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { ORDER_STATUS, TSellerOrder } from "@/lib/globals";
+import { ORDER_STATUS, TOrder, TSellerOrder } from "@/lib/globals";
 import { ReactNode, createContext, useContext, useState } from "react";
 import {
   IOrderDeliveryReceiptInput,
@@ -12,6 +12,7 @@ import { useRouter } from "next/navigation";
 import { Button } from "@/components/ui/button";
 import { Loader2Icon } from "lucide-react";
 import { SubmitHandler, useForm } from "react-hook-form";
+import { sortOrders } from "@/lib/helper";
 
 export const OrderManagementContext =
   createContext<TOrderManagementContext | null>(null);
@@ -51,7 +52,7 @@ export function OrderManagementContextProvider({
   });
 
   const orders = {
-    ALL: orders_data,
+    ALL: sortOrders(orders_data) as TSellerOrder[],
     PENDING: orders_data.filter((order) => order.order_status === "PENDING"),
     PAID: orders_data.filter((order) => order.order_status === "PAID"),
     PACKED: orders_data.filter((order) => order.order_status === "PACKED"),


### PR DESCRIPTION
This pull request adds the ability to sort customer and seller order lists by order date in descending order. It also includes a new helper function, `sortOrders`, which can be used to sort orders by status and date. This improves the user experience by allowing them to easily view their orders in the desired order.